### PR TITLE
Algo1 spec changes to inputdata and schedule

### DIFF
--- a/api/docs/api_schema.json
+++ b/api/docs/api_schema.json
@@ -514,10 +514,7 @@
             "$ref": "#/components/schemas/inputdata_professors"
           },
           "dimensions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/inputdata_dimensions"
-            }
+            "$ref": "#/components/schemas/inputdata_dimensions"
           },
           "preferences": {
             "type": "array",
@@ -531,10 +528,7 @@
           "loads": {
             "type": "array",
             "items": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
+              "type": "integer"
             }
           },
           "availabilities": {
@@ -547,6 +541,9 @@
             }
           },
           "p_tgt": {
+            "type": "integer"
+          },
+          "max_iter": {
             "type": "integer"
           }
         }

--- a/api/docs/api_schema.json
+++ b/api/docs/api_schema.json
@@ -476,7 +476,7 @@
         "type": "object"
       },
       "schedule": {
-        "required": ["assignments", "complete", "valid"],
+        "required": ["assignments", "complete", "valid", "reward", "iterations", "c_hat", "quality"],
         "type": "object",
         "properties": {
           "assignments": {
@@ -495,6 +495,18 @@
           "complete": {
             "type": "boolean",
             "nullable": true
+          },
+          "reward": {
+            "type": "float"
+          },
+          "iterations": {
+            "type": "integer"
+          },
+          "c_hat": {
+            "type": "float"
+          },
+          "quality": {
+            "type": "float"
           }
         }
       },


### PR DESCRIPTION
Our api spec requires the following changes:

To the schedule return value:

- Add the fields reward, quality, iterations, and c_hat

To the InputData input:

-Add the field max_iter (int)
-Modify the inputdata.dimensions to just be a dictionary, not a list of dictionaries
-Modify the inputdata.loads to be a list of ints, not a list of lists of ints

Please let me know if there's any issues or if there's any more changes I need to make to backend to implement these changes
